### PR TITLE
add Authorization to Access-Control-Allow-Headers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -88,7 +88,7 @@ func (f *File) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "*")
-		w.Header().Set("Access-Control-Allow-Headers", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "*, Authorization")
 		w.Header().Set("Access-Control-Max-Age", "60")
 		w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, post-check=0, pre-check=0")
 		w.Header().Set("Vary", "Accept-Encoding")
@@ -126,7 +126,7 @@ func (f *File) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		ModifyResponse: func(resp *http.Response) error {
 			resp.Header.Set("Access-Control-Allow-Origin", "*")
 			resp.Header.Set("Access-Control-Allow-Methods", "*")
-			resp.Header.Set("Access-Control-Allow-Headers", "*")
+			resp.Header.Set("Access-Control-Allow-Headers", "*, Authorization")
 			resp.Header.Set("Access-Control-Max-Age", "60")
 			resp.Header.Set("Cache-Control", "no-store, no-cache, must-revalidate, post-check=0, pre-check=0")
 			resp.Header.Set("Vary", "Accept-Encoding")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -68,7 +68,7 @@ func TestConfig(t *testing.T) {
 
 				Expect(res.Header.Get("Access-Control-Allow-Origin")).To(Equal("*"))
 				Expect(res.Header.Get("Access-Control-Allow-Methods")).To(Equal("*"))
-				Expect(res.Header.Get("Access-Control-Allow-Headers")).To(Equal("*"))
+				Expect(res.Header.Get("Access-Control-Allow-Headers")).To(Equal("*, Authorization"))
 				Expect(res.Header.Get("Access-Control-Max-Age")).To(Equal("60"))
 				Expect(res.Header.Get("Cache-Control")).To(Equal("no-store, no-cache, must-revalidate, post-check=0, pre-check=0"))
 				Expect(res.Header.Get("Vary")).To(Equal("Accept-Encoding"))


### PR DESCRIPTION
from the whatwg spec, a fully wide open  requires  be listed alongside the wildcard.

https://github.com/whatwg/fetch/commit/cdbb13c08650b10c9ebfc54d046bec0639e7ba7c

some browser engines reporting wildcard support as fixed/implemented, and others not:

## fixed ##
* chromium, https://bugs.chromium.org/p/chromium/issues/detail\?id\=615313
* edge, https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11169249/

## open ##
* webkit, https://bugs.webkit.org/show_bug.cgi\?id\=165508
* firefox, https://bugzilla.mozilla.org/show_bug.cgi\?id\=1309358